### PR TITLE
Add RGB composite example

### DIFF
--- a/combine_rgb.py
+++ b/combine_rgb.py
@@ -1,0 +1,28 @@
+import micasense.capture as capture
+
+# Paths to the individual band images
+BAND_FILES = [
+    'data/REDEDGE-MX/IMG_0001_1.tif',
+    'data/REDEDGE-MX/IMG_0001_2.tif',
+    'data/REDEDGE-MX/IMG_0001_3.tif',
+]
+
+# Output RGB filename
+OUTPUT_FILE = 'IMG_0001_RGB.jpg'
+
+
+def main():
+    # Create a Capture object from the list of band files
+    cap = capture.Capture.from_filelist(BAND_FILES)
+
+    # Align the images (computes radiance if needed)
+    cap.create_aligned_capture()
+
+    # Save the aligned stack as an RGB composite
+    cap.save_capture_as_rgb(OUTPUT_FILE)
+    print(f'Saved RGB image to {OUTPUT_FILE}')
+
+
+if __name__ == '__main__':
+    main()
+


### PR DESCRIPTION
## Summary
- add an example script that shows how to combine individual band images using `Capture.save_capture_as_rgb`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_684c16eef88c8323918ac4d7f594434e